### PR TITLE
Admin page authentication, correct status codes, updated tests

### DIFF
--- a/__tests__/route-auth.test.js
+++ b/__tests__/route-auth.test.js
@@ -30,6 +30,21 @@ const checkStatus = async (route, statusCode) => {
     expect(response.statusCode).toBe(statusCode);
 }
 
+// Unfortunately this code does not work inside the describe blocks
+async function checkRoute (route, userType) {
+    let name = route.name;
+    let option = route[userType];
+    if((typeof option) === 'string') {
+        test('accessing /' + name +  ' redirects to /' + option, async () => {
+            await checkRedirect('/' + name, '/' + option);
+        });
+    } else {
+        test('accessing /' + name + ' returns status: ' + option, async () => {
+            await checkStatus('/' + name, option);
+        });
+    }
+}
+
 const routes = [
     {
         name: '',
@@ -59,18 +74,18 @@ const routes = [
         student: 200,
         loggedout: 200
     },
-    {
-        name: 'create-assignment',
-        admin: 200,
-        instructor: 200,
-        student: 'courses',
-        loggedout: 'login'
-    },
+    // {   // Doesn't make sense to test this as a general route since it's tied to a course
+    //     name: 'create-assignment',
+    //     admin: 200,
+    //     instructor: 200,
+    //     student: 403,
+    //     loggedout: 'login'
+    // },
     {
         name: 'create-course',
         admin: 200,
         instructor: 200,
-        student: 'courses',
+        student: 403,
         loggedout: 'login'
     },
     {

--- a/__tests__/route-auth.test.js
+++ b/__tests__/route-auth.test.js
@@ -226,6 +226,6 @@ describe('while logged in as student', async () => {
     }
 
     test('cannot access non-visible course', async () => {
-        await checkStatus('/course?courseid=' + invisibleCourse._id, 302);
+        await checkStatus('/course?courseid=' + invisibleCourse._id, 403);
     });
 });

--- a/__tests__/route-auth.test.js
+++ b/__tests__/route-auth.test.js
@@ -41,8 +41,8 @@ const routes = [
     {
         name: 'admin',
         admin: 200,
-        instructor: 'courses',
-        student: 'courses',
+        instructor: 403,
+        student: 403,
         loggedout: 'login'
     },
     {
@@ -142,7 +142,7 @@ describe('while logged out', async () => {
             });
         } else {
             test('accessing /' + name + ' returns status: ' + option, async () => {
-                await checkStatus('/' + name, 200);
+                await checkStatus('/' + name, option);
             });
         }
     }
@@ -163,7 +163,7 @@ describe('while logged in as admin', async () => {
             });
         } else {
             test('accessing /' + name + ' returns status: ' + option, async () => {
-                await checkStatus('/' + name, 200);
+                await checkStatus('/' + name, option);
             });
         }
     }
@@ -184,7 +184,7 @@ describe('while logged in as instructor', async () => {
             });
         } else {
             test('accessing /' + name + ' returns status: ' + option, async () => {
-                await checkStatus('/' + name, 200);
+                await checkStatus('/' + name, option);
             });
         }
     }
@@ -205,7 +205,7 @@ describe('while logged in as student', async () => {
             });
         } else {
             test('accessing /' + name + ' returns status: ' + option, async () => {
-                await checkStatus('/' + name, 200);
+                await checkStatus('/' + name, option);
             });
         }
     }

--- a/db.js
+++ b/db.js
@@ -84,7 +84,7 @@ async function belongsToCourse(courseid, userid, instructor, admin = false) {
     if (instructor) {
         course = await Course.findOne({_id: courseid, instructors: userid}).exec();
     } else {
-        course = await Course.findOne({_id: courseid, students: userid}).exec();
+        course = await Course.findOne({_id: courseid, students: userid, visible: true}).exec();
     }
     return (course != null);
 }

--- a/models/User.js
+++ b/models/User.js
@@ -6,11 +6,11 @@ let ObjectId = Schema.ObjectId;
 
 // User model.
 let UserSchema = new Schema({
-    _id: { type: String, 'default': shortid.generate },    
+    _id: { type: String, 'default': shortid.generate },
     email:          { type: String, required: true },
     password:       { type: String, required: true },                 // Hashed.
     instructor:     { type: Boolean, required: true },                // Is this User an instructor?
-    admin:          { type: String, default: false, required: true }, // Is this User an admin?
+    admin:          { type: Boolean, default: false, required: true }, // Is this User an admin?
     name:           { first: String, last: String }
 });
 
@@ -21,7 +21,7 @@ UserSchema.pre('save', function(next) {
     if (!this.isModified('password')) {
         return next();
     }
-    
+
     try {
         let hash = bcrypt.hashSync(this.password, 6);
         this.password = hash;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,7 +2,11 @@ var express = require('express');
 var router =  express.Router();
 
 router.get('/', function(req, res, next) {
-    res.render('admin');
+    if(res.locals.user.admin === true) {
+        res.render('admin');
+    } else {
+        res.redirect('courses');
+    }
 });
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -5,7 +5,8 @@ router.get('/', function(req, res, next) {
     if(res.locals.user.admin === true) {
         res.render('admin');
     } else {
-        res.redirect('courses');
+        res.status(403);
+        res.render('error', {message: "You do not have access to this page."});
     }
 });
 

--- a/routes/course.js
+++ b/routes/course.js
@@ -4,6 +4,7 @@ let db = require('../db.js');
 
 router.get('/', async function(req, res, next) {
     if (!req.query.courseid) {
+        res.status(404);
         res.render('error', {message: "Missing course id."});
     }
     // Does this course exist?
@@ -12,6 +13,7 @@ router.get('/', async function(req, res, next) {
     // Does this user have access to this course?
     let belongs = await db.utils.belongsToCourse(req.query.courseid, res.locals.user._id, res.locals.user.instructor, res.locals.user.admin);
     if (!belongs) {
+        res.status(403);
         return res.render('error', {message: "You do not have access to this course."});
     }
 

--- a/routes/create-assignment.js
+++ b/routes/create-assignment.js
@@ -12,6 +12,7 @@ router.get('/', async function(req, res, next) {
         res.render('create-assignment', {courseid : req.query.courseid});
     } else {
         // Doesn't quite work due to format of error ejs.
+        res.status(403);
         res.render('error',JSON.parse('{ "message" : "You do not have permission to view this page." }'));
     }
 });
@@ -39,7 +40,7 @@ router.post('/', upload.single('spec'), async function(req, res, next) {
 
     newassignment.save(async (err) => {
         if (err) return res.status(500);
-    
+
         // Must save new assignment to course.
         try {
             await db.Course.findByIdAndUpdate(req.query.courseid,

--- a/routes/create-course.js
+++ b/routes/create-course.js
@@ -8,7 +8,9 @@ router.get('/', function(req, res, next) {
     if(instructor) {
         res.render('create-course');
     } else {
-        res.redirect('courses');
+        res.status(403);
+        // res.redirect('courses');
+        return res.render('error', {message: "You do not have access to this page."});
     }
 });
 
@@ -33,6 +35,7 @@ router.post('/', function(req, res, next) {
         course.save(err => {
             if(err) {
                 console.error(err);
+                res.status(500);
                 res.render('create-course', {
                     error: 'Unable to create course. Database Error.'
                 });
@@ -44,7 +47,9 @@ router.post('/', function(req, res, next) {
             }
         });
     } else {
-        res.redirect('courses');
+        res.status(403);
+        // res.redirect('courses');
+        return res.render('error', {message: "You do not have access to this page."});
     }
 });
 

--- a/routes/create-course.js
+++ b/routes/create-course.js
@@ -9,7 +9,6 @@ router.get('/', function(req, res, next) {
         res.render('create-course');
     } else {
         res.status(403);
-        // res.redirect('courses');
         return res.render('error', {message: "You do not have access to this page."});
     }
 });
@@ -48,7 +47,6 @@ router.post('/', function(req, res, next) {
         });
     } else {
         res.status(403);
-        // res.redirect('courses');
         return res.render('error', {message: "You do not have access to this page."});
     }
 });


### PR DESCRIPTION
Updates admin page authentication to only accept admins and throw a 403 otherwise. Additionally, return a 403 status code for pages that are not accessible due to privilege level, and updated the test cases to reflect that. Change some instance of redirecting back to courses to instead displaying a more descriptive error message.